### PR TITLE
Fixed python code style in longDescription

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,7 +1,3 @@
-# This repository adheres to the publiccode.yml standard by including this 
-# metadata file that makes public software easily discoverable.
-# More info at https://github.com/italia/publiccode.yml
-
 publiccodeYmlVersion: '0.2'
 name: pyWSArchiPRO
 releaseDate: '2019-02-01'
@@ -35,31 +31,20 @@ description:
     localisedName: pyWSArchiPRO
     shortDescription: 'Protocollazioni e recupero Documenti da WSArchiPRO con Python '
     longDescription: >
-      Protocollazioni e recupero Documenti da WSArchiPRO con Python tramite
-      interfaccia ws SOAP.
+      Protocollazione e recupero documenti da WSArchiPRO con Python tramite interfaccia ws SOAP.
 
+      Qui di seguito è presentato un esempio di recupero di un protocollo:
+      ```
+      from protocollo_ws.protocollo import Protocollo wsclient = Protocollo(wsdl_url=PROT_URL, username=PROT_LOGIN, password=PROT_PASSW, aoo=PROTOCOLLO_AOO, anno=2018, numero=234234)
 
-      ​
-
-       > `from protocollo\_ws.protocollo import Protocollo
-      wsclient = Protocollo(wsdl\_url=PROT\_URL,
-                            username=PROT\_LOGIN,
-                            password=PROT\_PASSW,
-                            aoo=PROTOCOLLO\_AOO,
-                            anno=2018, numero=234234)
-      # recupera
-
+      # Recupera
       wsclient.get()
-
-
-      # salva i files in locale
-
+      
+      # Salva i file in locale
       wsclient.dumpfiles()
-
-
-      # renderizza il documento che descrive il flusso di protocollazione
-      (dataXML)
-
-      wsclient.render\_dataXML()`
+      
+      # Renderizza il documento che descrive il flusso di protocollazione (dataXML).
+      wsclient.render_dataXML()
+      ```
     features:
-      - protocollazione
+      - Protocollazione


### PR DESCRIPTION
Ho sistemato la visualizzazione della `longDescription` nel publiccode.yml siccome attualmente nella scheda sul portale è poco leggibile. Ora dovrebbe essere meglio. 
Grazie molte @peppelinux!